### PR TITLE
Add media API with YouTube link support

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ app.use('/news', require('./src/routes/news.routes'))
 app.use('/event', require('./src/routes/event.routes'))
 app.use('/about', require('./src/routes/about.routes'))
 // app.use('/album', require(./src/routes/album.router))
-// app.use('/media', require('./src/routes/media.routes'))
+app.use('/media', require('./src/routes/media.routes'))
 app.use('/contact', require('./src/routes/contact.routes'))
 
 // Test API

--- a/doc/http/media.route.http
+++ b/doc/http/media.route.http
@@ -14,8 +14,7 @@ Content-Type: application/json
 {
   "title": "Live session",
   "description": "Version acoustique",
-  "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-  "albumId": 2
+  "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
 }
 
 ### Mettre à jour un média (JWT admin requis)

--- a/doc/http/media.route.http
+++ b/doc/http/media.route.http
@@ -1,0 +1,33 @@
+### Récupérer tous les médias
+GET {{baseUrl}}/media/getall
+Content-Type: application/json
+
+### Récupérer un média par ID
+GET {{baseUrl}}/media/id/7
+Content-Type: application/json
+
+### Créer un média (JWT admin requis)
+POST http://localhost:3030/media/create
+Authorization: Bearer {{jwt}}
+Content-Type: application/json
+
+{
+  "title": "Live session",
+  "description": "Version acoustique",
+  "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  "albumId": 2
+}
+
+### Mettre à jour un média (JWT admin requis)
+PATCH http://localhost:3030/media/update/7
+Authorization: Bearer {{jwt}}
+Content-Type: application/json
+
+{
+  "title": "Session studio",
+  "url": "https://youtu.be/dQw4w9WgXcQ"
+}
+
+### Supprimer un média (JWT admin requis)
+DELETE http://localhost:3030/media/delete/7
+Authorization: Bearer {{jwt}}

--- a/doc/media.md
+++ b/doc/media.md
@@ -1,0 +1,105 @@
+# API Médias
+
+Base API: `http://localhost:3030`
+
+La ressource média est exposée sous le préfixe `/media`. Les routes d'écriture nécessitent un JWT d'admin via l'en-tête `Authorization: Bearer <token>`. Les routes de lecture sont publiques.
+
+## Modèle de données
+| Champ       | Type     | Obligatoire | Description |
+|-------------|----------|-------------|-------------|
+| `id`        | integer  | oui         | Identifiant unique. |
+| `title`     | string   | oui         | Titre du média. |
+| `description` | text   | non         | Description longue du média. |
+| `url`       | string (URL YouTube) | oui | Lien YouTube intégré par le front. |
+| `albumId`   | integer  | non         | Album associé (optionnel). |
+| `authorId`  | integer  | oui (création) | Identifiant de l'admin ayant créé le média. |
+| `createdAt` | date     | oui         | Date de création. |
+| `updatedAt` | date     | oui         | Date de dernière mise à jour. |
+
+## Endpoints
+
+### GET `/media/getall`
+- **Auth**: aucune
+- **Réponse 200**
+```json
+{
+  "error": false,
+  "message": "Les médias ont bien été récupérés.",
+  "data": [
+    {
+      "id": 7,
+      "title": "Live session",
+      "description": "Version acoustique.",
+      "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "albumId": 2,
+      "authorId": 3,
+      "createdAt": "2024-04-02T12:00:00.000Z",
+      "updatedAt": "2024-04-02T12:00:00.000Z"
+    }
+  ]
+}
+```
+
+### GET `/media/id/:id`
+- **Auth**: aucune
+- **Paramètres**: `id` (integer, requis)
+- **Réponses**:
+  - `200`: objet média dans `data`.
+  - `400`: `Requête invalide.` si l'id n'est pas un entier.
+  - `404`: `Le média est introuvable.` si l'id n'existe pas.
+
+### POST `/media/create`
+- **Auth**: JWT admin requis
+- **Content-Type**: `application/json`
+- **Champs**:
+  - `title` *(string, requis)*
+  - `url` *(string, requis, lien YouTube)*
+  - `description` *(string, optionnel)*
+  - `albumId` *(integer, optionnel)*
+- **Réponse 201**
+```json
+{
+  "error": false,
+  "message": "Média créé avec succès."
+}
+```
+- **Erreurs fréquentes**:
+  - `400` si un champ obligatoire manque ou si l'URL n'est pas un lien YouTube valide.
+  - `401` si le JWT est manquant/invalidé.
+  - `404` si `albumId` est fourni mais inexistant.
+
+### PATCH `/media/update/:id`
+- **Auth**: JWT admin requis
+- **Paramètres**: `id` (integer, requis)
+- **Content-Type**: `application/json`
+- **Champs** (optionnels): `title`, `description`, `url`, `albumId`. L'URL doit rester un lien YouTube.
+- **Réponse 200**
+```json
+{
+  "error": false,
+  "message": "Média mis à jour avec succès.",
+  "data": {
+    "id": 7,
+    "title": "Session studio",
+    "description": "Clip officiel",
+    "url": "https://youtu.be/dQw4w9WgXcQ",
+    "albumId": 2,
+    "authorId": 3,
+    "createdAt": "2024-04-02T12:00:00.000Z",
+    "updatedAt": "2024-04-10T11:00:00.000Z"
+  }
+}
+```
+- **Erreurs fréquentes**: `400` pour un id ou une URL invalide, `404` si le média ou l'album n'existe pas, `401` si non authentifié.
+
+### DELETE `/media/delete/:id`
+- **Auth**: JWT admin requis
+- **Paramètres**: `id` (integer, requis)
+- **Réponse 200**
+```json
+{
+  "error": false,
+  "message": "Le média a été supprimé avec succès."
+}
+```
+- **Erreurs fréquentes**: `400` pour un id invalide, `404` si le média n'existe pas, `401` si non authentifié.

--- a/doc/media.md
+++ b/doc/media.md
@@ -11,7 +11,6 @@ La ressource média est exposée sous le préfixe `/media`. Les routes d'écritu
 | `title`     | string   | oui         | Titre du média. |
 | `description` | text   | non         | Description longue du média. |
 | `url`       | string (URL YouTube) | oui | Lien YouTube intégré par le front. |
-| `albumId`   | integer  | non         | Album associé (optionnel). |
 | `authorId`  | integer  | oui (création) | Identifiant de l'admin ayant créé le média. |
 | `createdAt` | date     | oui         | Date de création. |
 | `updatedAt` | date     | oui         | Date de dernière mise à jour. |
@@ -31,7 +30,6 @@ La ressource média est exposée sous le préfixe `/media`. Les routes d'écritu
       "title": "Live session",
       "description": "Version acoustique.",
       "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-      "albumId": 2,
       "authorId": 3,
       "createdAt": "2024-04-02T12:00:00.000Z",
       "updatedAt": "2024-04-02T12:00:00.000Z"
@@ -55,7 +53,6 @@ La ressource média est exposée sous le préfixe `/media`. Les routes d'écritu
   - `title` *(string, requis)*
   - `url` *(string, requis, lien YouTube)*
   - `description` *(string, optionnel)*
-  - `albumId` *(integer, optionnel)*
 - **Réponse 201**
 ```json
 {
@@ -66,13 +63,12 @@ La ressource média est exposée sous le préfixe `/media`. Les routes d'écritu
 - **Erreurs fréquentes**:
   - `400` si un champ obligatoire manque ou si l'URL n'est pas un lien YouTube valide.
   - `401` si le JWT est manquant/invalidé.
-  - `404` si `albumId` est fourni mais inexistant.
 
 ### PATCH `/media/update/:id`
 - **Auth**: JWT admin requis
 - **Paramètres**: `id` (integer, requis)
 - **Content-Type**: `application/json`
-- **Champs** (optionnels): `title`, `description`, `url`, `albumId`. L'URL doit rester un lien YouTube.
+- **Champs** (optionnels): `title`, `description`, `url`. L'URL doit rester un lien YouTube.
 - **Réponse 200**
 ```json
 {
@@ -83,14 +79,13 @@ La ressource média est exposée sous le préfixe `/media`. Les routes d'écritu
     "title": "Session studio",
     "description": "Clip officiel",
     "url": "https://youtu.be/dQw4w9WgXcQ",
-    "albumId": 2,
     "authorId": 3,
     "createdAt": "2024-04-02T12:00:00.000Z",
     "updatedAt": "2024-04-10T11:00:00.000Z"
   }
 }
 ```
-- **Erreurs fréquentes**: `400` pour un id ou une URL invalide, `404` si le média ou l'album n'existe pas, `401` si non authentifié.
+- **Erreurs fréquentes**: `400` pour un id ou une URL invalide, `404` si le média n'existe pas, `401` si non authentifié.
 
 ### DELETE `/media/delete/:id`
 - **Auth**: JWT admin requis

--- a/seeders/005-seed-medias.js
+++ b/seeders/005-seed-medias.js
@@ -14,7 +14,6 @@ module.exports = {
           description:
             "Un aperçu des répétitions filmées au studio avec un arrangement acoustique.",
           url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-          albumId: null,
           authorId: 1,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -24,7 +23,6 @@ module.exports = {
           description:
             "Clip vidéo officiel publié sur notre chaîne YouTube pour le single phare.",
           url: "https://youtu.be/3JZ_D3ELwOQ",
-          albumId: null,
           authorId: 1,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -34,7 +32,6 @@ module.exports = {
           description:
             "Interview tournée en coulisses juste avant le concert de fin de tournée.",
           url: "https://www.youtube.com/watch?v=oHg5SJYRHA0",
-          albumId: null,
           authorId: 2,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -44,7 +41,6 @@ module.exports = {
           description:
             "Performance enregistrée en extérieur avec une captation multi-caméras.",
           url: "https://youtu.be/l482T0yNkeo",
-          albumId: null,
           authorId: 2,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -54,7 +50,6 @@ module.exports = {
           description:
             "Explications détaillées pour rejouer les riffs principaux du dernier single.",
           url: "https://www.youtube.com/watch?v=fJ9rUzIMcZQ",
-          albumId: null,
           authorId: 1,
           createdAt: new Date(),
           updatedAt: new Date(),

--- a/seeders/005-seed-medias.js
+++ b/seeders/005-seed-medias.js
@@ -1,0 +1,74 @@
+"use strict";
+
+const path = require("path");
+require("dotenv").config({
+  path: path.resolve(__dirname, "../.env"),
+});
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    try {
+      await queryInterface.bulkInsert("medias", [
+        {
+          title: "Session live au studio",
+          description:
+            "Un aperçu des répétitions filmées au studio avec un arrangement acoustique.",
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          albumId: null,
+          authorId: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          title: "Clip officiel",
+          description:
+            "Clip vidéo officiel publié sur notre chaîne YouTube pour le single phare.",
+          url: "https://youtu.be/3JZ_D3ELwOQ",
+          albumId: null,
+          authorId: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          title: "Interview backstage",
+          description:
+            "Interview tournée en coulisses juste avant le concert de fin de tournée.",
+          url: "https://www.youtube.com/watch?v=oHg5SJYRHA0",
+          albumId: null,
+          authorId: 2,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          title: "Live session plein air",
+          description:
+            "Performance enregistrée en extérieur avec une captation multi-caméras.",
+          url: "https://youtu.be/l482T0yNkeo",
+          albumId: null,
+          authorId: 2,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          title: "Tutoriel guitare",
+          description:
+            "Explications détaillées pour rejouer les riffs principaux du dernier single.",
+          url: "https://www.youtube.com/watch?v=fJ9rUzIMcZQ",
+          albumId: null,
+          authorId: 1,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]);
+
+      console.log("Les médias ont été insérés avec succès.");
+    } catch (error) {
+      console.error("Erreur lors de l’insertion des médias :", error);
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete("medias", null, {});
+  },
+};

--- a/src/controllers/media.controller.js
+++ b/src/controllers/media.controller.js
@@ -1,5 +1,4 @@
 const Media = require('../models/media.model')
-const Album = require('../models/albums.model')
 
 const isValidYouTubeUrl = (url) => {
   const pattern = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/).+/i
@@ -8,7 +7,7 @@ const isValidYouTubeUrl = (url) => {
 
 exports.Create = async (req, res) => {
   try {
-    const { title, description, url, albumId } = req.body
+    const { title, description, url } = req.body
 
     if (!title || !url) {
       return res.status(400).json({
@@ -31,28 +30,10 @@ exports.Create = async (req, res) => {
       })
     }
 
-    if (albumId && isNaN(albumId)) {
-      return res.status(400).json({
-        error: true,
-        message: "Requête invalide. L'ID d'album doit être un entier valide.",
-      })
-    }
-
-    if (albumId) {
-      const album = await Album.findOne({ where: { id: parseInt(albumId, 10) } })
-      if (!album) {
-        return res.status(404).json({
-          error: true,
-          message: "L'album spécifié est introuvable.",
-        })
-      }
-    }
-
     await Media.create({
       title,
       description: description || null,
       url,
-      albumId: albumId ? parseInt(albumId, 10) : null,
       authorId: req.user.userId,
     })
 
@@ -122,7 +103,7 @@ exports.GetById = async (req, res) => {
 exports.Update = async (req, res) => {
   try {
     const { id } = req.params
-    const { title, description, url, albumId } = req.body
+    const { title, description, url } = req.body
 
     if (!req.user || !req.user.userId) {
       return res.status(401).json({
@@ -145,23 +126,6 @@ exports.Update = async (req, res) => {
       })
     }
 
-    if (albumId && isNaN(albumId)) {
-      return res.status(400).json({
-        error: true,
-        message: "Requête invalide. L'ID d'album doit être un entier valide.",
-      })
-    }
-
-    if (albumId) {
-      const album = await Album.findOne({ where: { id: parseInt(albumId, 10) } })
-      if (!album) {
-        return res.status(404).json({
-          error: true,
-          message: "L'album spécifié est introuvable.",
-        })
-      }
-    }
-
     const media = await Media.findOne({ where: { id: parseInt(id, 10) } })
 
     if (!media) {
@@ -175,7 +139,6 @@ exports.Update = async (req, res) => {
       title: title || media.title,
       description: description || media.description,
       url: url || media.url,
-      albumId: albumId ? parseInt(albumId, 10) : media.albumId,
       updatedAt: new Date(),
     })
 

--- a/src/controllers/media.controller.js
+++ b/src/controllers/media.controller.js
@@ -1,12 +1,229 @@
-// Create
-// Vérification des données (title, description, url, albumId, authentification via middleware)
-// Vérification de l'albumId
-// Mise en ligne de l'image sur le serveur et récupération de l'url
-// Update
-// Vérification des données (title, description, url, albumId, authentification via middleware)
-// Vérification de l'albumId
-// Mise à jour des champs uniquement rensignés sinon on garde les anciennes valeurs
-// Delete
-// Vérification des données (id du média, authentification via middleware)
-// Get / GetById
-// Vérification des données (id du média)
+const Media = require('../models/media.model')
+const Album = require('../models/albums.model')
+
+const isValidYouTubeUrl = (url) => {
+  const pattern = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/).+/i
+  return pattern.test(url)
+}
+
+exports.Create = async (req, res) => {
+  try {
+    const { title, description, url, albumId } = req.body
+
+    if (!title || !url) {
+      return res.status(400).json({
+        error: true,
+        message: 'Titre et URL YouTube sont obligatoires.',
+      })
+    }
+
+    if (!req.user || !req.user.userId) {
+      return res.status(401).json({
+        error: true,
+        message: 'Utilisateur non authentifié.',
+      })
+    }
+
+    if (!isValidYouTubeUrl(url)) {
+      return res.status(400).json({
+        error: true,
+        message: 'URL YouTube invalide.',
+      })
+    }
+
+    if (albumId && isNaN(albumId)) {
+      return res.status(400).json({
+        error: true,
+        message: "Requête invalide. L'ID d'album doit être un entier valide.",
+      })
+    }
+
+    if (albumId) {
+      const album = await Album.findOne({ where: { id: parseInt(albumId, 10) } })
+      if (!album) {
+        return res.status(404).json({
+          error: true,
+          message: "L'album spécifié est introuvable.",
+        })
+      }
+    }
+
+    await Media.create({
+      title,
+      description: description || null,
+      url,
+      albumId: albumId ? parseInt(albumId, 10) : null,
+      authorId: req.user.userId,
+    })
+
+    return res.status(201).json({
+      error: false,
+      message: 'Média créé avec succès.',
+    })
+  } catch (error) {
+    console.error(error)
+    return res.status(500).json({
+      error: true,
+      message: 'Une erreur interne est survenue.',
+    })
+  }
+}
+
+exports.GetAll = async (req, res) => {
+  try {
+    const medias = await Media.findAll()
+
+    return res.status(200).json({
+      error: false,
+      message: 'Les médias ont bien été récupérés.',
+      data: medias,
+    })
+  } catch (error) {
+    return res.status(500).json({
+      error: true,
+      message: 'Une erreur interne est survenue, veuillez réessayer plus tard.',
+    })
+  }
+}
+
+exports.GetById = async (req, res) => {
+  try {
+    const { id } = req.params
+
+    if (!id || isNaN(id)) {
+      return res.status(400).json({
+        error: true,
+        message: 'Requête invalide.',
+      })
+    }
+
+    const media = await Media.findOne({ where: { id: parseInt(id, 10) } })
+
+    if (!media) {
+      return res.status(404).json({
+        error: true,
+        message: 'Le média est introuvable.',
+      })
+    }
+
+    return res.status(200).json({
+      error: false,
+      message: 'Le média a été récupéré.',
+      data: media,
+    })
+  } catch (error) {
+    return res.status(500).json({
+      error: true,
+      message: 'Une erreur interne est survenue, veuillez réessayer plus tard.',
+    })
+  }
+}
+
+exports.Update = async (req, res) => {
+  try {
+    const { id } = req.params
+    const { title, description, url, albumId } = req.body
+
+    if (!req.user || !req.user.userId) {
+      return res.status(401).json({
+        error: true,
+        message: 'Utilisateur non authentifié.',
+      })
+    }
+
+    if (!id || isNaN(id)) {
+      return res.status(400).json({
+        error: true,
+        message: "Requête invalide. L'ID doit être un entier valide.",
+      })
+    }
+
+    if (url && !isValidYouTubeUrl(url)) {
+      return res.status(400).json({
+        error: true,
+        message: 'URL YouTube invalide.',
+      })
+    }
+
+    if (albumId && isNaN(albumId)) {
+      return res.status(400).json({
+        error: true,
+        message: "Requête invalide. L'ID d'album doit être un entier valide.",
+      })
+    }
+
+    if (albumId) {
+      const album = await Album.findOne({ where: { id: parseInt(albumId, 10) } })
+      if (!album) {
+        return res.status(404).json({
+          error: true,
+          message: "L'album spécifié est introuvable.",
+        })
+      }
+    }
+
+    const media = await Media.findOne({ where: { id: parseInt(id, 10) } })
+
+    if (!media) {
+      return res.status(404).json({
+        error: true,
+        message: 'Le média est introuvable.',
+      })
+    }
+
+    const updatedMedia = await media.update({
+      title: title || media.title,
+      description: description || media.description,
+      url: url || media.url,
+      albumId: albumId ? parseInt(albumId, 10) : media.albumId,
+      updatedAt: new Date(),
+    })
+
+    return res.status(200).json({
+      error: false,
+      message: 'Média mis à jour avec succès.',
+      data: updatedMedia,
+    })
+  } catch (error) {
+    console.error('Erreur lors de la mise à jour du média :', error)
+    return res.status(500).json({
+      error: true,
+      message: 'Une erreur interne est survenue.',
+    })
+  }
+}
+
+exports.Delete = async (req, res) => {
+  try {
+    const { id } = req.params
+
+    if (!id || isNaN(id)) {
+      return res.status(400).json({
+        error: true,
+        message: "Requête invalide : ID du média manquant ou incorrect.",
+      })
+    }
+
+    const media = await Media.findOne({ where: { id: parseInt(id, 10) } })
+
+    if (!media) {
+      return res.status(404).json({
+        error: true,
+        message: 'Média introuvable.',
+      })
+    }
+
+    await media.destroy()
+
+    return res.status(200).json({
+      error: false,
+      message: 'Le média a été supprimé avec succès.',
+    })
+  } catch (error) {
+    console.error('Erreur lors de la suppression du média :', error)
+    return res.status(500).json({
+      error: true,
+      message: 'Une erreur interne est survenue.',
+    })
+  }
+}

--- a/src/models/media.model.js
+++ b/src/models/media.model.js
@@ -26,11 +26,7 @@ Media.init({
         type: DataTypes.STRING,
         allowNull: true
       },
-    
-      albumId: {
-        type: DataTypes.INTEGER,
-      },
-    
+
       authorId: {
         type: DataTypes.INTEGER,
       },

--- a/src/routes/media.routes.js
+++ b/src/routes/media.routes.js
@@ -1,20 +1,16 @@
 const express = require('express')
+const auth = require('../middlewares/authenticate.middlewares')
+const { roleMiddleware } = require('../middlewares/role.middlewares')
 const router = express.Router()
-const {Create, Update, GetAll, GetById, Delete } = require('../controllers/media.controller')
+const { Create, Update, GetAll, GetById, Delete } = require('../controllers/media.controller')
 
-// Création d'un média
-router.post('/create', Create);
+// Routes publiques
+router.get('/getall', GetAll)
+router.get('/id/:id', GetById)
 
-// Mise à jour d'un média par son ID
-router.patch('/update/:id', Update);
+// Routes protégées
+router.post('/create', auth, roleMiddleware('admin'), Create)
+router.patch('/update/:id', auth, roleMiddleware('admin'), Update)
+router.delete('/delete/:id', auth, roleMiddleware('admin'), Delete)
 
-// Récupération de tous les médias
-router.get('/', GetAll);
-
-// Récupération d'un média par son ID
-router.get('/:id', GetById);
-
-// Suppression d'un média par son ID
-router.delete('/delete/:id', Delete);
-
-module.exports = router;
+module.exports = router

--- a/tests/unit/controllers/media.controller.test.js
+++ b/tests/unit/controllers/media.controller.test.js
@@ -4,12 +4,7 @@ jest.mock('../../../src/models/media.model', () => ({
   findOne: jest.fn(),
 }))
 
-jest.mock('../../../src/models/albums.model', () => ({
-  findOne: jest.fn(),
-}))
-
 const Media = require('../../../src/models/media.model')
-const Album = require('../../../src/models/albums.model')
 const {
   Create,
   GetAll,
@@ -75,40 +70,12 @@ describe('Media Controller', () => {
       })
     })
 
-    it("retourne 400 si l'albumId est invalide", async () => {
-      const res = createRes()
-
-      await Create(
-        { body: { title: 'Live', url: 'https://youtu.be/abc', albumId: 'abc' }, user: { userId: 1 } },
-        res
-      )
-
-      expect(res.status).toHaveBeenCalledWith(400)
-    })
-
-    it("retourne 404 si l'album n'existe pas", async () => {
-      const res = createRes()
-      Album.findOne.mockResolvedValue(null)
-
-      await Create(
-        { body: { title: 'Live', url: 'https://youtu.be/abc', albumId: 5 }, user: { userId: 1 } },
-        res
-      )
-
-      expect(res.status).toHaveBeenCalledWith(404)
-      expect(res.json).toHaveBeenCalledWith({
-        error: true,
-        message: "L'album spécifié est introuvable.",
-      })
-    })
-
     it('crée un média avec succès', async () => {
       const res = createRes()
-      Album.findOne.mockResolvedValue({ id: 2 })
       Media.create.mockResolvedValue({ id: 1 })
 
       await Create(
-        { body: { title: 'Live', url: 'https://youtu.be/abc', albumId: 2 }, user: { userId: 1 } },
+        { body: { title: 'Live', url: 'https://youtu.be/abc' }, user: { userId: 1 } },
         res
       )
 
@@ -116,7 +83,6 @@ describe('Media Controller', () => {
         title: 'Live',
         description: null,
         url: 'https://youtu.be/abc',
-        albumId: 2,
         authorId: 1,
       })
       expect(res.status).toHaveBeenCalledWith(201)
@@ -273,43 +239,14 @@ describe('Media Controller', () => {
       })
     })
 
-    it("retourne 400 si l'albumId fourni est invalide", async () => {
-      const res = createRes()
-
-      await Update(
-        { params: { id: '2' }, body: { albumId: 'abc' }, user: { userId: 1 } },
-        res
-      )
-
-      expect(res.status).toHaveBeenCalledWith(400)
-    })
-
-    it("retourne 404 si l'album fourni est introuvable", async () => {
-      const res = createRes()
-      Album.findOne.mockResolvedValue(null)
-
-      await Update(
-        { params: { id: '2' }, body: { albumId: 3 }, user: { userId: 1 } },
-        res
-      )
-
-      expect(res.status).toHaveBeenCalledWith(404)
-      expect(res.json).toHaveBeenCalledWith({
-        error: true,
-        message: "L'album spécifié est introuvable.",
-      })
-    })
-
     it('met à jour un média avec succès', async () => {
       const res = createRes()
-      Album.findOne.mockResolvedValue({ id: 3 })
       const update = jest.fn().mockResolvedValue({ id: 12, url: 'https://youtu.be/updated' })
       Media.findOne.mockResolvedValue({
         id: 12,
         title: 'Old',
         description: 'Desc',
         url: 'https://youtu.be/old',
-        albumId: 3,
         update,
       })
 
@@ -326,7 +263,6 @@ describe('Media Controller', () => {
         title: 'New title',
         description: 'Desc',
         url: 'https://youtu.be/updated',
-        albumId: 3,
         updatedAt: expect.any(Date),
       })
       expect(res.status).toHaveBeenCalledWith(200)

--- a/tests/unit/controllers/media.controller.test.js
+++ b/tests/unit/controllers/media.controller.test.js
@@ -1,0 +1,407 @@
+jest.mock('../../../src/models/media.model', () => ({
+  create: jest.fn(),
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+}))
+
+jest.mock('../../../src/models/albums.model', () => ({
+  findOne: jest.fn(),
+}))
+
+const Media = require('../../../src/models/media.model')
+const Album = require('../../../src/models/albums.model')
+const {
+  Create,
+  GetAll,
+  GetById,
+  Update,
+  Delete,
+} = require('../../../src/controllers/media.controller')
+
+const createRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn(),
+})
+
+describe('Media Controller', () => {
+  let consoleErrorSpy
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  describe('Create', () => {
+    it('retourne 400 si des champs sont manquants', async () => {
+      const res = createRes()
+
+      await Create({ body: { title: '', url: '' }, user: {} }, res)
+
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Titre et URL YouTube sont obligatoires.',
+      })
+    })
+
+    it('retourne 401 si utilisateur non authentifié', async () => {
+      const res = createRes()
+
+      await Create({ body: { title: 'Live', url: 'https://youtu.be/abc' }, user: {} }, res)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Utilisateur non authentifié.',
+      })
+    })
+
+    it('retourne 400 si url non valide', async () => {
+      const res = createRes()
+
+      await Create(
+        { body: { title: 'Live', url: 'https://vimeo.com/1' }, user: { userId: 1 } },
+        res
+      )
+
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'URL YouTube invalide.',
+      })
+    })
+
+    it("retourne 400 si l'albumId est invalide", async () => {
+      const res = createRes()
+
+      await Create(
+        { body: { title: 'Live', url: 'https://youtu.be/abc', albumId: 'abc' }, user: { userId: 1 } },
+        res
+      )
+
+      expect(res.status).toHaveBeenCalledWith(400)
+    })
+
+    it("retourne 404 si l'album n'existe pas", async () => {
+      const res = createRes()
+      Album.findOne.mockResolvedValue(null)
+
+      await Create(
+        { body: { title: 'Live', url: 'https://youtu.be/abc', albumId: 5 }, user: { userId: 1 } },
+        res
+      )
+
+      expect(res.status).toHaveBeenCalledWith(404)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: "L'album spécifié est introuvable.",
+      })
+    })
+
+    it('crée un média avec succès', async () => {
+      const res = createRes()
+      Album.findOne.mockResolvedValue({ id: 2 })
+      Media.create.mockResolvedValue({ id: 1 })
+
+      await Create(
+        { body: { title: 'Live', url: 'https://youtu.be/abc', albumId: 2 }, user: { userId: 1 } },
+        res
+      )
+
+      expect(Media.create).toHaveBeenCalledWith({
+        title: 'Live',
+        description: null,
+        url: 'https://youtu.be/abc',
+        albumId: 2,
+        authorId: 1,
+      })
+      expect(res.status).toHaveBeenCalledWith(201)
+      expect(res.json).toHaveBeenCalledWith({
+        error: false,
+        message: 'Média créé avec succès.',
+      })
+    })
+
+    it('retourne 500 si la création échoue', async () => {
+      const res = createRes()
+      Media.create.mockRejectedValue(new Error('db'))
+
+      await Create(
+        { body: { title: 'Live', url: 'https://youtu.be/abc' }, user: { userId: 1 } },
+        res
+      )
+
+      expect(res.status).toHaveBeenCalledWith(500)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Une erreur interne est survenue.',
+      })
+    })
+  })
+
+  describe('GetAll', () => {
+    it('renvoie la liste complète des médias', async () => {
+      const res = createRes()
+      const medias = [{ id: 1 }, { id: 2 }]
+      Media.findAll.mockResolvedValue(medias)
+
+      await GetAll({}, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({
+        error: false,
+        message: 'Les médias ont bien été récupérés.',
+        data: medias,
+      })
+    })
+
+    it('renvoie 500 en cas derreur lors de la récupération', async () => {
+      const res = createRes()
+      Media.findAll.mockRejectedValue(new Error('db'))
+
+      await GetAll({}, res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Une erreur interne est survenue, veuillez réessayer plus tard.',
+      })
+    })
+  })
+
+  describe('GetById', () => {
+    it('retourne 400 si id invalide', async () => {
+      const res = createRes()
+
+      await GetById({ params: { id: 'abc' } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(400)
+    })
+
+    it('retourne 404 si média manquant', async () => {
+      const res = createRes()
+      Media.findOne.mockResolvedValue(null)
+
+      await GetById({ params: { id: '7' } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(404)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Le média est introuvable.',
+      })
+    })
+
+    it('retourne 200 avec la ressource', async () => {
+      const res = createRes()
+      const media = { id: 3 }
+      Media.findOne.mockResolvedValue(media)
+
+      await GetById({ params: { id: '3' } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({
+        error: false,
+        message: 'Le média a été récupéré.',
+        data: media,
+      })
+    })
+
+    it('renvoie 500 si une erreur inattendue survient', async () => {
+      const res = createRes()
+      Media.findOne.mockRejectedValue(new Error('db'))
+
+      await GetById({ params: { id: '2' } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Une erreur interne est survenue, veuillez réessayer plus tard.',
+      })
+    })
+  })
+
+  describe('Update', () => {
+    it('refuse si utilisateur non authentifié', async () => {
+      const res = createRes()
+
+      await Update({ params: { id: '1' }, body: {} }, res)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+    })
+
+    it('retourne 400 si id invalide', async () => {
+      const res = createRes()
+
+      await Update({ params: { id: 'abc' }, body: {}, user: { userId: 1 } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: "Requête invalide. L'ID doit être un entier valide.",
+      })
+    })
+
+    it('retourne 404 si média introuvable', async () => {
+      const res = createRes()
+      Media.findOne.mockResolvedValue(null)
+
+      await Update({ params: { id: '8' }, body: {}, user: { userId: 1 } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(404)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Le média est introuvable.',
+      })
+    })
+
+    it('refuse une URL non YouTube', async () => {
+      const res = createRes()
+
+      await Update(
+        { params: { id: '1' }, body: { url: 'https://example.com' }, user: { userId: 2 } },
+        res
+      )
+
+      expect(res.status).toHaveBeenCalledWith(400)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'URL YouTube invalide.',
+      })
+    })
+
+    it("retourne 400 si l'albumId fourni est invalide", async () => {
+      const res = createRes()
+
+      await Update(
+        { params: { id: '2' }, body: { albumId: 'abc' }, user: { userId: 1 } },
+        res
+      )
+
+      expect(res.status).toHaveBeenCalledWith(400)
+    })
+
+    it("retourne 404 si l'album fourni est introuvable", async () => {
+      const res = createRes()
+      Album.findOne.mockResolvedValue(null)
+
+      await Update(
+        { params: { id: '2' }, body: { albumId: 3 }, user: { userId: 1 } },
+        res
+      )
+
+      expect(res.status).toHaveBeenCalledWith(404)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: "L'album spécifié est introuvable.",
+      })
+    })
+
+    it('met à jour un média avec succès', async () => {
+      const res = createRes()
+      Album.findOne.mockResolvedValue({ id: 3 })
+      const update = jest.fn().mockResolvedValue({ id: 12, url: 'https://youtu.be/updated' })
+      Media.findOne.mockResolvedValue({
+        id: 12,
+        title: 'Old',
+        description: 'Desc',
+        url: 'https://youtu.be/old',
+        albumId: 3,
+        update,
+      })
+
+      await Update(
+        {
+          params: { id: '12' },
+          body: { title: 'New title', url: 'https://youtu.be/updated' },
+          user: { userId: 9 },
+        },
+        res
+      )
+
+      expect(update).toHaveBeenCalledWith({
+        title: 'New title',
+        description: 'Desc',
+        url: 'https://youtu.be/updated',
+        albumId: 3,
+        updatedAt: expect.any(Date),
+      })
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({
+        error: false,
+        message: 'Média mis à jour avec succès.',
+        data: { id: 12, url: 'https://youtu.be/updated' },
+      })
+    })
+
+    it('retourne 500 en cas derreur serveur pendant la mise à jour', async () => {
+      const res = createRes()
+      Media.findOne.mockRejectedValue(new Error('db error'))
+
+      await Update({ params: { id: '1' }, body: {}, user: { userId: 1 } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Une erreur interne est survenue.',
+      })
+    })
+  })
+
+  describe('Delete', () => {
+    it('retourne 400 si id manquant', async () => {
+      const res = createRes()
+
+      await Delete({ params: { id: '' } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(400)
+    })
+
+    it('retourne 404 si la ressource est absente', async () => {
+      const res = createRes()
+      Media.findOne.mockResolvedValue(null)
+
+      await Delete({ params: { id: '6' } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(404)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Média introuvable.',
+      })
+    })
+
+    it('supprime un média avec succès', async () => {
+      const res = createRes()
+      const destroy = jest.fn().mockResolvedValue()
+      Media.findOne.mockResolvedValue({ id: 4, destroy })
+
+      await Delete({ params: { id: '4' } }, res)
+
+      expect(destroy).toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({
+        error: false,
+        message: 'Le média a été supprimé avec succès.',
+      })
+    })
+
+    it('retourne 500 en cas derreur lors de la suppression', async () => {
+      const res = createRes()
+      Media.findOne.mockResolvedValue({
+        id: 4,
+        destroy: jest.fn().mockRejectedValue(new Error('destroy failed')),
+      })
+
+      await Delete({ params: { id: '4' } }, res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+      expect(res.json).toHaveBeenCalledWith({
+        error: true,
+        message: 'Une erreur interne est survenue.',
+      })
+    })
+  })
+})

--- a/tests/unit/controllers/media.controller.test.js
+++ b/tests/unit/controllers/media.controller.test.js
@@ -23,7 +23,7 @@ describe('Media Controller', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { })
   })
 
   afterEach(() => {
@@ -265,12 +265,40 @@ describe('Media Controller', () => {
         url: 'https://youtu.be/updated',
         updatedAt: expect.any(Date),
       })
-      expect(res.status).toHaveBeenCalledWith(200)
       expect(res.json).toHaveBeenCalledWith({
         error: false,
         message: 'Média mis à jour avec succès.',
         data: { id: 12, url: 'https://youtu.be/updated' },
       })
+    })
+
+    it('utilise les anciennes valeurs si non fournies dans le body', async () => {
+      const res = createRes()
+      const update = jest.fn().mockResolvedValue({ id: 12, title: 'Old', url: 'https://youtu.be/old' })
+      Media.findOne.mockResolvedValue({
+        id: 12,
+        title: 'Old',
+        description: 'Desc',
+        url: 'https://youtu.be/old',
+        update,
+      })
+
+      await Update(
+        {
+          params: { id: '12' },
+          body: {}, // Body vide
+          user: { userId: 9 },
+        },
+        res
+      )
+
+      expect(update).toHaveBeenCalledWith({
+        title: 'Old',
+        description: 'Desc',
+        url: 'https://youtu.be/old',
+        updatedAt: expect.any(Date),
+      })
+      expect(res.status).toHaveBeenCalledWith(200)
     })
 
     it('retourne 500 en cas derreur serveur pendant la mise à jour', async () => {


### PR DESCRIPTION
## Summary
- implement media controller CRUD logic with YouTube URL validation and optional album checks
- secure media routes and expose the media endpoints under `/media`, documenting usage with new HTTP examples
- add comprehensive unit tests for the media controller

## Testing
- not run (npm command unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693413b17ff8832a99ba2dd3862b8090)